### PR TITLE
Import dependencies from the `vendored` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ similar project for Rust, [powerpack](https://github.com/rossmacarthur/powerpack
 It comes with a CLI that helps bootstrapping, maintaining and packaging the workflow.
 
 Dependencies are vendored and packaged with the workflow so that they don't need to be installed into the system Python.
+See the [section on adding dependencies](#adding-dependencies) for details.
 
 ## Installation
 
@@ -75,10 +76,23 @@ response to stdout, where it is being picked up by the next input.
 A minimal example for a script filter workflow looks like this:
 
 ```python
+from vendored.pyfred.model import Environment, OutputItem, ScriptFilterOutput
+from vendored.pyfred.workflow import script_filter
+
 @script_filter
 def main(script_path: Path, args_from_alfred: list[str], env: Optional[Environment]) -> ScriptFilterOutput:
     return ScriptFilterOutput(items=[OutputItem(title="Hello Alfred!")])
 ```
+
+## Adding dependencies
+
+When running the workflow, Alfred will use the system Python interpreter to run the script. Third-party libraries are
+not available in the interpreter unless explicitly installed. In order to not pollute the system Python, dependencies
+can be vendored with the workflow using the `pyfred vendor` command. It is also automatically run with `pyfred package`.
+
+If you add dependencies to your `requirements.txt` file, you need to run `pyfred vendor` to download them and make sure
+you import them from the `vendored` directory. For example: `from vendored.reuests import get` instead of
+`from requests import get`.
 
 ## Adding icons
 

--- a/docs/pyfred.html
+++ b/docs/pyfred.html
@@ -26,6 +26,7 @@
     <li><a href="#installation">Installation</a></li>
     <li><a href="#using-the-cli">Using the CLI</a></li>
     <li><a href="#creating-a-workflow">Creating a workflow</a></li>
+    <li><a href="#adding-dependencies">Adding dependencies</a></li>
     <li><a href="#adding-icons">Adding icons</a></li>
     <li><a href="#distribution-through-github-releases">Distribution through GitHub releases</a></li>
   </ul></li>
@@ -60,7 +61,8 @@ similar project for Rust, <a href="https://github.com/rossmacarthur/powerpack">p
 
 <p>It comes with a CLI that helps bootstrapping, maintaining and packaging the workflow.</p>
 
-<p>Dependencies are vendored and packaged with the workflow so that they don't need to be installed into the system Python.</p>
+<p>Dependencies are vendored and packaged with the workflow so that they don't need to be installed into the system Python.
+See the <a href="#adding-dependencies">section on adding dependencies</a> for details.</p>
 
 <h2 id="installation">Installation</h2>
 
@@ -135,11 +137,24 @@ response to stdout, where it is being picked up by the next input.</p>
 <p>A minimal example for a script filter workflow looks like this:</p>
 
 <div class="pdoc-code codehilite">
-<pre><span></span><code><span class="nd">@script_filter</span>
+<pre><span></span><code><span class="kn">from</span> <span class="nn">vendored.pyfred.model</span> <span class="kn">import</span> <span class="n">Environment</span><span class="p">,</span> <span class="n">OutputItem</span><span class="p">,</span> <span class="n">ScriptFilterOutput</span>
+<span class="kn">from</span> <span class="nn">vendored.pyfred.workflow</span> <span class="kn">import</span> <span class="n">script_filter</span>
+
+<span class="nd">@script_filter</span>
 <span class="k">def</span> <span class="nf">main</span><span class="p">(</span><span class="n">script_path</span><span class="p">:</span> <span class="n">Path</span><span class="p">,</span> <span class="n">args_from_alfred</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span> <span class="n">env</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">Environment</span><span class="p">])</span> <span class="o">-&gt;</span> <span class="n">ScriptFilterOutput</span><span class="p">:</span>
     <span class="k">return</span> <span class="n">ScriptFilterOutput</span><span class="p">(</span><span class="n">items</span><span class="o">=</span><span class="p">[</span><span class="n">OutputItem</span><span class="p">(</span><span class="n">title</span><span class="o">=</span><span class="s2">&quot;Hello Alfred!&quot;</span><span class="p">)])</span>
 </code></pre>
 </div>
+
+<h2 id="adding-dependencies">Adding dependencies</h2>
+
+<p>When running the workflow, Alfred will use the system Python interpreter to run the script. Third-party libraries are
+not available in the interpreter unless explicitly installed. In order to not pollute the system Python, dependencies
+can be vendored with the workflow using the <code>pyfred vendor</code> command. It is also automatically run with <code>pyfred package</code>.</p>
+
+<p>If you add dependencies to your <code>requirements.txt</code> file, you need to run <code>pyfred vendor</code> to download them and make sure
+you import them from the <code>vendored</code> directory. For example: <code>from vendored.reuests import get</code> instead of
+<code>from requests import get</code>.</p>
 
 <h2 id="adding-icons">Adding icons</h2>
 

--- a/pyfred/template/workflow/workflow.py
+++ b/pyfred/template/workflow/workflow.py
@@ -4,8 +4,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from pyfred.model import Environment, OutputItem, ScriptFilterOutput
-from pyfred.workflow import script_filter
+from vendored.pyfred.model import Environment, OutputItem, ScriptFilterOutput
+from vendored.pyfred.workflow import script_filter
 
 
 @script_filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ line-length = 120
 
 [tool.mypy]
 exclude = [
-    "^pyfred/tests"
+    "^pyfred/tests",
+    "^pyfred/template",
 ]
 
 [build-system]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyfred-cli
-version = 0.1.2
+version = 0.1.3
 author = Björn Marschollek
 project_urls=
     Source Code = https://github.com/muffix/pyfred-cli


### PR DESCRIPTION
Updates the template to import dependencies from the `vendored` package rather than the system interpreter.

Added a section in the docs to clarify.