### PR TITLE
Only publish release if tag is refs/heads/main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Tag must point at top of main branch
+      run: |
+        git merge-base --is-ancestor refs/heads/main $GITHUB_REF
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
   generate-docs:
-    name: Publish documentation to GitHub Pages
+    name: Generate docs
     runs-on: ubuntu-latest
     needs: [publish]
 
@@ -78,6 +78,7 @@ jobs:
   # Deploy the artifact to GitHub pages.
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.
   deploy-docs:
+    name: Deploy docs to GitHub Pages
     needs: [generate-docs]
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
+# Documentation
+docs
+
 # Sphinx documentation
 docs/_build/
 


### PR DESCRIPTION
To avoid accidental releases due to incorrect tags, this adds a check to
make sure the tag points at the head of the main branch.

`git merge-base --is-ancestor` exits with code 0 if the first ref is an
ancestor of the second one and with 1 otherwise.