### PR TITLE
Fix workflow decorator import

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        pip install -e '.' -e '.[test]' -e '.[doc]'
+        pip install -e '.[test]' -e '.[doc]'
     - name: Run pytest
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## UNRELEASED
+## v0.1.5
 
+- Fixed the workflow decorator which imported the incorrect model for validation
 - Added an optional `--upgrade` flag to the `vendor` command which will be passed through to the `pip install` command
-  if set.
+  if set
 
 ## v0.1.4 - 2022-10-23
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyfred-cli
-version = 0.1.4
+version = 0.1.5
 author = Björn Marschollek
 project_urls=
     Source Code = https://github.com/muffix/pyfred-cli


### PR DESCRIPTION
The decorator checks the type of the response returned byt he workflow, but was importing it from the interpreter's dependencies, not from the vendored ones. This was introduced with `v0.1.3` which should now be considered broken.